### PR TITLE
Add zero_v_gen! and composed! proc macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+zero_v_gen/target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,14 @@ homepage = "https://github.com/fergaljoconnor/zero_v"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+zero_v_gen = { path = "zero_v_gen", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
+
+[features]
+default = ["gen"]
+gen = ["zero_v_gen"]
 
 [[bench]]
 name = "integer_ops"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ A library for implementing iterators over function outputs for collections of
 types implementing a common trait, without using vtables/ dynamic polymorphism.
 """
 license = "MIT OR Apache-2.0"
-authors = ["fergal <fergaljamesoconnor@gmail.com>"]
+authors = ["fergal <fergaljamesoconnor@gmail.com>", "marshall <mcu@hey.com>"]
 edition = "2018"
 exclude = [
     "blob/*",

--- a/benches/integer_ops.rs
+++ b/benches/integer_ops.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use zero_v::{compose, composed, zero_v_gen};
+use zero_v::{compose, zero_v};
 
-#[zero_v_gen]
+#[zero_v(trait_types)]
 trait IntOp {
     fn execute(&self, input: usize) -> usize;
 }
@@ -127,7 +127,7 @@ impl<const VALUE: usize> IntOp for ConstLShifter<VALUE> {
     }
 }
 
-#[composed(IntOp as IntOps)]
+#[zero_v(fn_generics, IntOp as IntOps)]
 fn bench_composed(input: usize, ops: &IntOps) -> usize {
     ops.iter_execute(input).sum()
 }

--- a/benches/integer_ops.rs
+++ b/benches/integer_ops.rs
@@ -1,71 +1,9 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use zero_v::{compose, compose_nodes, Composite, NextNode, Node};
+use zero_v::{compose, composed, zero_v_gen};
 
-// The trait we want members of our collection to implement
+#[zero_v_gen]
 trait IntOp {
     fn execute(&self, input: usize) -> usize;
-}
-
-// Execute the trait's function on the object at a certain nesting level
-trait IntOpAtLevel {
-    fn execute_at_level(&self, input: usize, level: usize) -> Option<usize>;
-}
-
-impl IntOpAtLevel for () {
-    #[inline]
-    fn execute_at_level(&self, _input: usize, _level: usize) -> Option<usize> {
-        None
-    }
-}
-
-impl<A: IntOp, B: NextNode + IntOpAtLevel> IntOpAtLevel for Node<A, B> {
-    #[inline]
-    fn execute_at_level(&self, input: usize, level: usize) -> Option<usize> {
-        if level != 0 {
-            self.next.execute_at_level(input, level - 1)
-        } else {
-            Some(self.data.execute(input))
-        }
-    }
-}
-
-// Iterate over the results of executing the trait's function on the input at
-// each nesting level starting from the outermost level.
-trait IterIntOps<NodeType: NextNode + IntOpAtLevel> {
-    fn iter_execute(&self, input: usize) -> CompositeIterator<'_, NodeType>;
-}
-
-impl<Nodes: NextNode + IntOpAtLevel> IterIntOps<Nodes> for Composite<Nodes> {
-    fn iter_execute(&self, input: usize) -> CompositeIterator<'_, Nodes> {
-        CompositeIterator::new(&self.head, input)
-    }
-}
-
-struct CompositeIterator<'a, Nodes: NextNode + IntOpAtLevel> {
-    level: usize,
-    input: usize,
-    parent: &'a Nodes,
-}
-
-impl<'a, Nodes: NextNode + IntOpAtLevel> CompositeIterator<'a, Nodes> {
-    fn new(parent: &'a Nodes, input: usize) -> Self {
-        Self {
-            parent,
-            input,
-            level: 0,
-        }
-    }
-}
-
-impl<'a, Nodes: NextNode + IntOpAtLevel> Iterator for CompositeIterator<'a, Nodes> {
-    type Item = usize;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let result = self.parent.execute_at_level(self.input, self.level);
-        self.level += 1;
-        result
-    }
 }
 
 struct Adder {
@@ -189,12 +127,9 @@ impl<const VALUE: usize> IntOp for ConstLShifter<VALUE> {
     }
 }
 
-fn bench_composed<NodeType, Composed>(input: usize, composed: &Composed) -> usize
-where
-    NodeType: IntOpAtLevel + NextNode,
-    Composed: IterIntOps<NodeType>,
-{
-    composed.iter_execute(input).sum()
+#[composed(IntOp as IntOps)]
+fn bench_composed(input: usize, ops: &IntOps) -> usize {
+    ops.iter_execute(input).sum()
 }
 
 fn bench_trait_objects(input: usize, ops: &Vec<Box<dyn IntOp>>) -> usize {
@@ -305,9 +240,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| bench_trait_objects(black_box(20), black_box(&ops_dyn_const)))
     });
 
-    group.bench_function("Baseline", |b| {
-        b.iter(|| bench_baseline(black_box(20)))
-    });
+    group.bench_function("Baseline", |b| b.iter(|| bench_baseline(black_box(20))));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/composite.rs
+++ b/src/composite.rs
@@ -102,10 +102,10 @@ macro_rules! compose_nodes {
         ()
     };
     ($val: expr) => {
-       Node::base($val)
+       $crate::Node::base($val)
     };
     ($left: expr, $($right: expr), +) => {
-        Node::new($left, compose_nodes!( $($right), +))
+        $crate::Node::new($left, $crate::compose_nodes!( $($right), +))
     };
 }
 
@@ -115,7 +115,7 @@ macro_rules! compose_nodes {
 ///
 /// # Example usage
 /// ```
-/// use zero_v::{compose, compose_nodes, Composite, Node};
+/// use zero_v::{compose, Composite, Node};
 ///
 /// let nodes = compose!(1, 2);
 /// assert_eq!(nodes, Composite::new(Node::new(1, Node::base(2))));
@@ -123,7 +123,7 @@ macro_rules! compose_nodes {
 #[macro_export]
 macro_rules! compose {
     ($($right: expr), *) => {
-        Composite::new(compose_nodes!( $($right), *))
+        $crate::Composite::new($crate::compose_nodes!( $($right), *))
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,3 +192,9 @@ mod composite;
 mod test;
 
 pub use composite::{Composite, NextNode, Node};
+
+#[cfg(feature = "gen")]
+extern crate zero_v_gen;
+
+#[cfg(feature = "gen")]
+pub use zero_v_gen::{composed, zero_v_gen};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,4 +197,4 @@ pub use composite::{Composite, NextNode, Node};
 extern crate zero_v_gen;
 
 #[cfg(feature = "gen")]
-pub use zero_v_gen::{composed, zero_v_gen};
+pub use zero_v_gen::zero_v;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,7 @@
-use crate::{compose, compose_nodes};
-use crate::composite::{Composite, NextNode, Node};
+use crate as zero_v;
+use crate::{compose, zero_v_gen};
 
+#[zero_v_gen]
 trait IntOp {
     fn execute(&self, input: usize) -> usize;
 }
@@ -17,62 +18,6 @@ impl<const VALUE: usize> IntOp for Adder<VALUE> {
     fn execute(&self, input: usize) -> usize {
         input + VALUE
     }
-}
-
-trait IntOpAtLevel {
-    fn execute_at_level(&self, input: usize, level: usize) -> Option<usize>;
-}
-
-impl<A: IntOp, B: NextNode + IntOpAtLevel> IntOpAtLevel for Node<A, B> {
-    fn execute_at_level(&self, input: usize, level: usize) -> Option<usize> {
-        if level == 0 {
-            Some(self.data.execute(input))
-        } else {
-            self.next.execute_at_level(input, level - 1)
-        }
-    }
-}
-
-impl IntOpAtLevel for () {
-    fn execute_at_level(&self, _input: usize, _level: usize) -> Option<usize> {
-        None
-    }
-}
-
-struct CompositeIterator<'a, Nodes: NextNode + IntOpAtLevel> {
-    level: usize,
-    input: usize,
-    parent: &'a Nodes,
-}
-
-impl<'a, Nodes: NextNode + IntOpAtLevel> CompositeIterator<'a, Nodes> {
-    fn new(parent: &'a Nodes, input: usize) -> Self {
-        Self {
-            parent,
-            input,
-            level: 0,
-        }
-    }
-}
-
-impl<'a, Nodes: NextNode + IntOpAtLevel> Iterator for CompositeIterator<'a, Nodes> {
-    type Item = usize;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let result = self.parent.execute_at_level(self.input, self.level);
-        self.level += 1;
-        result
-    }
-}
-
-trait IterExecute<Nodes: NextNode + IntOpAtLevel> {
-   fn iter_execute(&self, input: usize) -> CompositeIterator<'_, Nodes>;
-}
-
-impl<Nodes: NextNode + IntOpAtLevel> IterExecute<Nodes> for Composite<Nodes> {
-   fn iter_execute(&self, input: usize) -> CompositeIterator<'_, Nodes> {
-       CompositeIterator::new(&self.head, input)
-   }
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,7 @@
 use crate as zero_v;
-use crate::{compose, zero_v_gen};
+use crate::{compose, zero_v};
 
-#[zero_v_gen]
+#[zero_v(trait_types)]
 trait IntOp {
     fn execute(&self, input: usize) -> usize;
 }

--- a/zero_v_gen/Cargo.toml
+++ b/zero_v_gen/Cargo.toml
@@ -3,8 +3,10 @@ name = "zero_v_gen"
 version = "0.1.0"
 description = "Implementation helper macros for zero_v"
 license = "MIT OR Apache-2.0"
-authors = ["marshall <mcu@hey.com>"]
+authors = ["fergal <fergaljamesoconnor@gmail.com>", "marshall <mcu@hey.com>"]
 edition = "2018"
+repository = "https://github.com/fergaljoconnor/zero_v"
+homepage = "https://github.com/fergaljoconnor/zero_v"
 
 [lib]
 proc-macro = true

--- a/zero_v_gen/Cargo.toml
+++ b/zero_v_gen/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "zero_v_gen"
+version = "0.1.0"
+description = "Implementation helper macros for zero_v"
+license = "MIT OR Apache-2.0"
+authors = ["marshall <mcu@hey.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+convert_case = "0.4"
+
+[dev-dependencies]
+syn = { version = "1.0", features = ["full", "extra-traits"] }
+zero_v = { path = ".." }

--- a/zero_v_gen/src/fn_generics.rs
+++ b/zero_v_gen/src/fn_generics.rs
@@ -1,0 +1,43 @@
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{parse_macro_input, parse_quote, ItemFn, Token};
+
+use crate::Idents;
+
+pub(crate) struct FnGenerics {
+    trait_ident: Ident,
+    _as: Token![as],
+    type_name: Ident,
+}
+
+impl FnGenerics {
+    pub(crate) fn generate(&self, input: TokenStream) -> TokenStream {
+        let type_name = &self.type_name;
+        let idents = Idents::from_ident(self.trait_ident.clone());
+        let mut f = parse_macro_input!(input as ItemFn);
+
+        let level_trait = idents.level_trait();
+        let iter_trait = idents.iter_trait();
+
+        f.sig.generics.params.push(parse_quote! { NodeType });
+        f.sig.generics.params.push(parse_quote! { #type_name });
+        f.sig.generics.where_clause = Some(parse_quote! {
+            where NodeType: #level_trait + NextNode,
+                  #type_name: #iter_trait<NodeType>
+        });
+
+        TokenStream::from(quote! { #f })
+    }
+}
+
+impl Parse for FnGenerics {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            trait_ident: input.parse()?,
+            _as: input.parse()?,
+            type_name: input.parse()?,
+        })
+    }
+}

--- a/zero_v_gen/src/idents.rs
+++ b/zero_v_gen/src/idents.rs
@@ -1,0 +1,60 @@
+use convert_case::{Case, Casing};
+use proc_macro2::Ident;
+
+use quote::format_ident;
+use syn::{ItemTrait, TraitItem};
+
+pub(crate) struct Idents {
+    main: Ident,
+    main_methods: Vec<Ident>,
+}
+
+impl Idents {
+    pub(crate) fn from_trait(main: ItemTrait) -> Self {
+        let main_methods = main.items.into_iter().filter_map(|i| match i {
+            TraitItem::Method(m) => Some(m.sig.ident),
+            _ => None,
+        });
+
+        Self {
+            main: main.ident,
+            main_methods: main_methods.collect(),
+        }
+    }
+
+    pub(crate) fn from_ident(main: Ident) -> Self {
+        Self {
+            main,
+            main_methods: vec![],
+        }
+    }
+
+    pub(crate) fn level_trait(&self) -> Ident {
+        format_ident!("{}AtLevel", self.main)
+    }
+
+    pub(crate) fn level_methods<'a>(&'a self) -> impl Iterator<Item = Ident> + 'a {
+        self.main_methods
+            .iter()
+            .map(|m| format_ident!("{}_at_level", m))
+    }
+
+    pub(crate) fn iter_trait(&self) -> Ident {
+        format_ident!("Iter{}", self.main)
+    }
+
+    pub(crate) fn iter_methods<'a>(&'a self) -> impl Iterator<Item = Ident> + 'a {
+        self.main_methods
+            .iter()
+            .map(|m| format_ident!("iter_{}", m))
+    }
+
+    pub(crate) fn composite_iters<'a>(&'a self) -> impl Iterator<Item = Ident> + 'a {
+        self.main_methods.iter().map(|m| {
+            format_ident!(
+                "CompositeIterator{}",
+                m.to_string().to_case(Case::UpperCamel)
+            )
+        })
+    }
+}

--- a/zero_v_gen/src/lib.rs
+++ b/zero_v_gen/src/lib.rs
@@ -1,254 +1,39 @@
-use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
-use quote::{format_ident, quote};
 use syn::parse::{Parse, ParseStream};
-use syn::punctuated::Punctuated;
-use syn::token::Comma;
-use syn::{
-    parse_macro_input, parse_quote, FnArg, ItemFn, ItemTrait, Pat, PatType, ReturnType, Token,
-    TraitItem, Type,
-};
+use syn::{parse_macro_input, Token};
 
-struct Idents {
-    main: Ident,
-    main_methods: Vec<Ident>,
+mod fn_generics;
+mod idents;
+mod trait_types;
+
+pub(crate) use idents::Idents;
+
+enum ZeroVGen {
+    TraitTypes(trait_types::TraitTypes),
+    FnGenerics(fn_generics::FnGenerics),
 }
 
-impl Idents {
-    pub fn from_trait(main: ItemTrait) -> Self {
-        let main_methods = main.items.into_iter().filter_map(|i| match i {
-            TraitItem::Method(m) => Some(m.sig.ident),
-            _ => None,
-        });
-
-        Self {
-            main: main.ident,
-            main_methods: main_methods.collect(),
-        }
-    }
-
-    pub fn from_ident(main: Ident) -> Self {
-        Self {
-            main,
-            main_methods: vec![],
-        }
-    }
-
-    pub fn level_trait(&self) -> Ident {
-        format_ident!("{}AtLevel", self.main)
-    }
-
-    pub fn level_methods<'a>(&'a self) -> impl Iterator<Item = Ident> + 'a {
-        self.main_methods
-            .iter()
-            .map(|m| format_ident!("{}_at_level", m))
-    }
-
-    pub fn iter_trait(&self) -> Ident {
-        format_ident!("Iter{}", self.main)
-    }
-
-    pub fn iter_methods<'a>(&'a self) -> impl Iterator<Item = Ident> + 'a {
-        self.main_methods
-            .iter()
-            .map(|m| format_ident!("iter_{}", m))
-    }
-
-    pub fn composite_iters<'a>(&'a self) -> impl Iterator<Item = Ident> + 'a {
-        self.main_methods.iter().map(|m| {
-            format_ident!(
-                "CompositeIterator{}",
-                m.to_string().to_case(Case::UpperCamel)
-            )
-        })
-    }
-}
-
-#[proc_macro_attribute]
-pub fn zero_v_gen(_args: TokenStream, input: TokenStream) -> TokenStream {
-    let trait_type = parse_macro_input!(input as ItemTrait);
-    let idents = Idents::from_trait(trait_type.clone());
-    let trait_ident = &trait_type.ident;
-    let trait_methods = || {
-        trait_type.items.iter().filter_map(|i| match i {
-            TraitItem::Method(m) => Some(m),
-            _ => None,
-        })
-    };
-
-    let trait_method_idents: Vec<Ident> = trait_methods().map(|m| m.sig.ident.clone()).collect();
-    let trait_method_inputs = trait_methods()
-        .map(|m| {
-            m.sig
-                .inputs
-                .iter()
-                .filter_map(|arg| match arg {
-                    FnArg::Typed(_) => Some(arg.clone()),
-                    _ => None,
-                })
-                .collect::<Punctuated<FnArg, Comma>>()
-        })
-        .collect::<Vec<_>>();
-    let trait_method_args = trait_methods()
-        .map(|m| {
-            m.sig
-                .inputs
-                .iter()
-                .filter_map(|arg| match arg {
-                    FnArg::Typed(PatType { pat, .. }) => match **pat {
-                        Pat::Ident(ref i) => Some(i.ident.clone()),
-                        _ => None,
-                    },
-                    _ => None,
-                })
-                .collect::<Punctuated<Ident, Comma>>()
-        })
-        .collect::<Vec<_>>();
-
-    let trait_method_self_args = trait_method_args
-        .iter()
-        .map(|args| {
-            let iter = args.iter();
-            quote! { #(self.#iter),* }
-        })
-        .collect::<Vec<_>>();
-
-    let trait_method_outputs: Vec<Type> = trait_methods()
-        .map(|m| match &m.sig.output {
-            ReturnType::Default => parse_quote! { () },
-            ReturnType::Type(_, ty) => *ty.clone(),
-        })
-        .collect();
-
-    let level_trait = idents.level_trait();
-    let level_methods: Vec<Ident> = idents.level_methods().collect();
-    let level_method_inputs = trait_methods()
-        .map(|m| m.sig.inputs.clone())
-        .collect::<Vec<_>>();
-
-    let level_method_outputs: Vec<Type> = trait_methods()
-        .map(|m| match &m.sig.output {
-            ReturnType::Default => parse_quote! { Option<()> },
-            ReturnType::Type(_, ty) => parse_quote! { Option<#ty> },
-        })
-        .collect();
-
-    let iter_trait = idents.iter_trait();
-    let iter_methods: Vec<Ident> = idents.iter_methods().collect();
-    let composite_iters: Vec<Ident> = idents.composite_iters().collect();
-
-    let tokens = quote! {
-        use zero_v::{Composite, NextNode, Node};
-        #trait_type
-
-        trait #level_trait {
-            #(
-                fn #level_methods(#level_method_inputs, level: usize) -> #level_method_outputs;
-            )*
-        }
-
-        impl #level_trait for () {
-            #(
-                #[allow(unused)]
-                fn #level_methods(#level_method_inputs, level: usize) -> #level_method_outputs {
-                    None
-                }
-            )*
-        }
-
-        impl<A: #trait_ident, B: NextNode + #level_trait> #level_trait for Node<A, B> {
-            #(
-                fn #level_methods(#level_method_inputs, level: usize) -> #level_method_outputs {
-                    if level != 0 {
-                        self.next.#level_methods(#trait_method_args, level - 1)
-                    } else {
-                        Some(self.data.#trait_method_idents(#trait_method_args))
-                    }
-                }
-            )*
-        }
-
-        trait #iter_trait<NodeType: NextNode + #level_trait> {
-            #(
-                fn #iter_methods(#level_method_inputs) -> #composite_iters<'_, NodeType>;
-            )*
-        }
-
-        impl<Nodes: NextNode + #level_trait> #iter_trait<Nodes> for Composite<Nodes> {
-            #(
-                fn #iter_methods(#level_method_inputs) -> #composite_iters<'_, Nodes> {
-                    #composite_iters::new(&self.head, #trait_method_args)
-                }
-            )*
-        }
-
-        #(
-            struct #composite_iters<'a, Nodes: NextNode + #level_trait> {
-                level: usize,
-                #trait_method_inputs,
-                parent: &'a Nodes,
-            }
-
-
-            impl<'a, Nodes: NextNode + #level_trait> #composite_iters<'a, Nodes> {
-                fn new(parent: &'a Nodes, #trait_method_inputs) -> Self {
-                    Self {
-                        parent,
-                        #trait_method_args,
-                        level: 0,
-                    }
-                }
-            }
-
-            impl<'a, Nodes: NextNode + #level_trait> Iterator for #composite_iters<'a, Nodes> {
-                type Item = #trait_method_outputs;
-
-                #[inline]
-                fn next(&mut self) -> Option<Self::Item> {
-                    let result = self.parent.#level_methods(#trait_method_self_args, self.level);
-                    self.level += 1;
-                    result
-                }
-            }
-        )*
-    };
-
-    TokenStream::from(tokens)
-}
-
-struct Composed {
-    trait_ident: Ident,
-    _as: Token![as],
-    type_name: Ident,
-}
-
-impl Parse for Composed {
+impl Parse for ZeroVGen {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        Ok(Self {
-            trait_ident: input.parse()?,
-            _as: input.parse()?,
-            type_name: input.parse()?,
-        })
+        let ident: Ident = input.parse()?;
+        let _comma_token: Option<Token![,]> = input.parse()?;
+
+        match ident.to_string().as_str() {
+            "trait_types" => input.parse().map(Self::TraitTypes),
+            "fn_generics" => input.parse().map(Self::FnGenerics),
+            _ => Err(syn::Error::new(
+                ident.span(),
+                "expected one of `trait_types` | `fn_generics`",
+            )),
+        }
     }
 }
 
 #[proc_macro_attribute]
-pub fn composed(args: TokenStream, input: TokenStream) -> TokenStream {
-    let composed = parse_macro_input!(args as Composed);
-    let type_name = &composed.type_name;
-    let idents = Idents::from_ident(composed.trait_ident.clone());
-    let mut f = parse_macro_input!(input as ItemFn);
-
-    let level_trait = idents.level_trait();
-    let iter_trait = idents.iter_trait();
-
-    f.sig.generics.params.push(parse_quote! { NodeType });
-    f.sig.generics.params.push(parse_quote! { #type_name });
-    f.sig.generics.where_clause = Some(parse_quote! {
-        where NodeType: #level_trait + NextNode,
-              #type_name: #iter_trait<NodeType>
-    });
-
-    TokenStream::from(quote! { #f })
+pub fn zero_v(args: TokenStream, input: TokenStream) -> TokenStream {
+    match parse_macro_input!(args as ZeroVGen) {
+        ZeroVGen::TraitTypes(t) => t.generate(input),
+        ZeroVGen::FnGenerics(g) => g.generate(input),
+    }
 }

--- a/zero_v_gen/src/lib.rs
+++ b/zero_v_gen/src/lib.rs
@@ -1,0 +1,254 @@
+use convert_case::{Case, Casing};
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+use syn::{
+    parse_macro_input, parse_quote, FnArg, ItemFn, ItemTrait, Pat, PatType, ReturnType, Token,
+    TraitItem, Type,
+};
+
+struct Idents {
+    main: Ident,
+    main_methods: Vec<Ident>,
+}
+
+impl Idents {
+    pub fn from_trait(main: ItemTrait) -> Self {
+        let main_methods = main.items.into_iter().filter_map(|i| match i {
+            TraitItem::Method(m) => Some(m.sig.ident),
+            _ => None,
+        });
+
+        Self {
+            main: main.ident,
+            main_methods: main_methods.collect(),
+        }
+    }
+
+    pub fn from_ident(main: Ident) -> Self {
+        Self {
+            main,
+            main_methods: vec![],
+        }
+    }
+
+    pub fn level_trait(&self) -> Ident {
+        format_ident!("{}AtLevel", self.main)
+    }
+
+    pub fn level_methods<'a>(&'a self) -> impl Iterator<Item = Ident> + 'a {
+        self.main_methods
+            .iter()
+            .map(|m| format_ident!("{}_at_level", m))
+    }
+
+    pub fn iter_trait(&self) -> Ident {
+        format_ident!("Iter{}", self.main)
+    }
+
+    pub fn iter_methods<'a>(&'a self) -> impl Iterator<Item = Ident> + 'a {
+        self.main_methods
+            .iter()
+            .map(|m| format_ident!("iter_{}", m))
+    }
+
+    pub fn composite_iters<'a>(&'a self) -> impl Iterator<Item = Ident> + 'a {
+        self.main_methods.iter().map(|m| {
+            format_ident!(
+                "CompositeIterator{}",
+                m.to_string().to_case(Case::UpperCamel)
+            )
+        })
+    }
+}
+
+#[proc_macro_attribute]
+pub fn zero_v_gen(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let trait_type = parse_macro_input!(input as ItemTrait);
+    let idents = Idents::from_trait(trait_type.clone());
+    let trait_ident = &trait_type.ident;
+    let trait_methods = || {
+        trait_type.items.iter().filter_map(|i| match i {
+            TraitItem::Method(m) => Some(m),
+            _ => None,
+        })
+    };
+
+    let trait_method_idents: Vec<Ident> = trait_methods().map(|m| m.sig.ident.clone()).collect();
+    let trait_method_inputs = trait_methods()
+        .map(|m| {
+            m.sig
+                .inputs
+                .iter()
+                .filter_map(|arg| match arg {
+                    FnArg::Typed(_) => Some(arg.clone()),
+                    _ => None,
+                })
+                .collect::<Punctuated<FnArg, Comma>>()
+        })
+        .collect::<Vec<_>>();
+    let trait_method_args = trait_methods()
+        .map(|m| {
+            m.sig
+                .inputs
+                .iter()
+                .filter_map(|arg| match arg {
+                    FnArg::Typed(PatType { pat, .. }) => match **pat {
+                        Pat::Ident(ref i) => Some(i.ident.clone()),
+                        _ => None,
+                    },
+                    _ => None,
+                })
+                .collect::<Punctuated<Ident, Comma>>()
+        })
+        .collect::<Vec<_>>();
+
+    let trait_method_self_args = trait_method_args
+        .iter()
+        .map(|args| {
+            let iter = args.iter();
+            quote! { #(self.#iter),* }
+        })
+        .collect::<Vec<_>>();
+
+    let trait_method_outputs: Vec<Type> = trait_methods()
+        .map(|m| match &m.sig.output {
+            ReturnType::Default => parse_quote! { () },
+            ReturnType::Type(_, ty) => *ty.clone(),
+        })
+        .collect();
+
+    let level_trait = idents.level_trait();
+    let level_methods: Vec<Ident> = idents.level_methods().collect();
+    let level_method_inputs = trait_methods()
+        .map(|m| m.sig.inputs.clone())
+        .collect::<Vec<_>>();
+
+    let level_method_outputs: Vec<Type> = trait_methods()
+        .map(|m| match &m.sig.output {
+            ReturnType::Default => parse_quote! { Option<()> },
+            ReturnType::Type(_, ty) => parse_quote! { Option<#ty> },
+        })
+        .collect();
+
+    let iter_trait = idents.iter_trait();
+    let iter_methods: Vec<Ident> = idents.iter_methods().collect();
+    let composite_iters: Vec<Ident> = idents.composite_iters().collect();
+
+    let tokens = quote! {
+        use zero_v::{Composite, NextNode, Node};
+        #trait_type
+
+        trait #level_trait {
+            #(
+                fn #level_methods(#level_method_inputs, level: usize) -> #level_method_outputs;
+            )*
+        }
+
+        impl #level_trait for () {
+            #(
+                #[allow(unused)]
+                fn #level_methods(#level_method_inputs, level: usize) -> #level_method_outputs {
+                    None
+                }
+            )*
+        }
+
+        impl<A: #trait_ident, B: NextNode + #level_trait> #level_trait for Node<A, B> {
+            #(
+                fn #level_methods(#level_method_inputs, level: usize) -> #level_method_outputs {
+                    if level != 0 {
+                        self.next.#level_methods(#trait_method_args, level - 1)
+                    } else {
+                        Some(self.data.#trait_method_idents(#trait_method_args))
+                    }
+                }
+            )*
+        }
+
+        trait #iter_trait<NodeType: NextNode + #level_trait> {
+            #(
+                fn #iter_methods(#level_method_inputs) -> #composite_iters<'_, NodeType>;
+            )*
+        }
+
+        impl<Nodes: NextNode + #level_trait> #iter_trait<Nodes> for Composite<Nodes> {
+            #(
+                fn #iter_methods(#level_method_inputs) -> #composite_iters<'_, Nodes> {
+                    #composite_iters::new(&self.head, #trait_method_args)
+                }
+            )*
+        }
+
+        #(
+            struct #composite_iters<'a, Nodes: NextNode + #level_trait> {
+                level: usize,
+                #trait_method_inputs,
+                parent: &'a Nodes,
+            }
+
+
+            impl<'a, Nodes: NextNode + #level_trait> #composite_iters<'a, Nodes> {
+                fn new(parent: &'a Nodes, #trait_method_inputs) -> Self {
+                    Self {
+                        parent,
+                        #trait_method_args,
+                        level: 0,
+                    }
+                }
+            }
+
+            impl<'a, Nodes: NextNode + #level_trait> Iterator for #composite_iters<'a, Nodes> {
+                type Item = #trait_method_outputs;
+
+                #[inline]
+                fn next(&mut self) -> Option<Self::Item> {
+                    let result = self.parent.#level_methods(#trait_method_self_args, self.level);
+                    self.level += 1;
+                    result
+                }
+            }
+        )*
+    };
+
+    TokenStream::from(tokens)
+}
+
+struct Composed {
+    trait_ident: Ident,
+    _as: Token![as],
+    type_name: Ident,
+}
+
+impl Parse for Composed {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            trait_ident: input.parse()?,
+            _as: input.parse()?,
+            type_name: input.parse()?,
+        })
+    }
+}
+
+#[proc_macro_attribute]
+pub fn composed(args: TokenStream, input: TokenStream) -> TokenStream {
+    let composed = parse_macro_input!(args as Composed);
+    let type_name = &composed.type_name;
+    let idents = Idents::from_ident(composed.trait_ident.clone());
+    let mut f = parse_macro_input!(input as ItemFn);
+
+    let level_trait = idents.level_trait();
+    let iter_trait = idents.iter_trait();
+
+    f.sig.generics.params.push(parse_quote! { NodeType });
+    f.sig.generics.params.push(parse_quote! { #type_name });
+    f.sig.generics.where_clause = Some(parse_quote! {
+        where NodeType: #level_trait + NextNode,
+              #type_name: #iter_trait<NodeType>
+    });
+
+    TokenStream::from(quote! { #f })
+}

--- a/zero_v_gen/src/trait_types.rs
+++ b/zero_v_gen/src/trait_types.rs
@@ -1,0 +1,173 @@
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+use syn::{
+    parse_macro_input, parse_quote, FnArg, ItemTrait, Pat, PatType, ReturnType, TraitItem, Type,
+};
+
+use crate::Idents;
+
+pub(crate) struct TraitTypes;
+
+impl TraitTypes {
+    pub(crate) fn generate(&self, input: TokenStream) -> TokenStream {
+        let trait_type = parse_macro_input!(input as ItemTrait);
+        let idents = Idents::from_trait(trait_type.clone());
+        let trait_ident = &trait_type.ident;
+        let trait_methods = || {
+            trait_type.items.iter().filter_map(|i| match i {
+                TraitItem::Method(m) => Some(m),
+                _ => None,
+            })
+        };
+
+        let trait_method_idents: Vec<Ident> =
+            trait_methods().map(|m| m.sig.ident.clone()).collect();
+        let trait_method_inputs = trait_methods()
+            .map(|m| {
+                m.sig
+                    .inputs
+                    .iter()
+                    .filter_map(|arg| match arg {
+                        FnArg::Typed(_) => Some(arg.clone()),
+                        _ => None,
+                    })
+                    .collect::<Punctuated<FnArg, Comma>>()
+            })
+            .collect::<Vec<_>>();
+        let trait_method_args = trait_methods()
+            .map(|m| {
+                m.sig
+                    .inputs
+                    .iter()
+                    .filter_map(|arg| match arg {
+                        FnArg::Typed(PatType { pat, .. }) => match **pat {
+                            Pat::Ident(ref i) => Some(i.ident.clone()),
+                            _ => None,
+                        },
+                        _ => None,
+                    })
+                    .collect::<Punctuated<Ident, Comma>>()
+            })
+            .collect::<Vec<_>>();
+
+        let trait_method_self_args = trait_method_args
+            .iter()
+            .map(|args| {
+                let iter = args.iter();
+                quote! { #(self.#iter),* }
+            })
+            .collect::<Vec<_>>();
+
+        let trait_method_outputs: Vec<Type> = trait_methods()
+            .map(|m| match &m.sig.output {
+                ReturnType::Default => parse_quote! { () },
+                ReturnType::Type(_, ty) => *ty.clone(),
+            })
+            .collect();
+
+        let level_trait = idents.level_trait();
+        let level_methods: Vec<Ident> = idents.level_methods().collect();
+        let level_method_inputs = trait_methods()
+            .map(|m| m.sig.inputs.clone())
+            .collect::<Vec<_>>();
+
+        let level_method_outputs: Vec<Type> = trait_methods()
+            .map(|m| match &m.sig.output {
+                ReturnType::Default => parse_quote! { Option<()> },
+                ReturnType::Type(_, ty) => parse_quote! { Option<#ty> },
+            })
+            .collect();
+
+        let iter_trait = idents.iter_trait();
+        let iter_methods: Vec<Ident> = idents.iter_methods().collect();
+        let composite_iters: Vec<Ident> = idents.composite_iters().collect();
+
+        let tokens = quote! {
+            use zero_v::{Composite, NextNode, Node};
+            #trait_type
+
+            trait #level_trait {
+                #(
+                    fn #level_methods(#level_method_inputs, level: usize) -> #level_method_outputs;
+                )*
+            }
+
+            impl #level_trait for () {
+                #(
+                    #[allow(unused)]
+                    fn #level_methods(#level_method_inputs, level: usize) -> #level_method_outputs {
+                        None
+                    }
+                )*
+            }
+
+            impl<A: #trait_ident, B: NextNode + #level_trait> #level_trait for Node<A, B> {
+                #(
+                    fn #level_methods(#level_method_inputs, level: usize) -> #level_method_outputs {
+                        if level != 0 {
+                            self.next.#level_methods(#trait_method_args, level - 1)
+                        } else {
+                            Some(self.data.#trait_method_idents(#trait_method_args))
+                        }
+                    }
+                )*
+            }
+
+            trait #iter_trait<NodeType: NextNode + #level_trait> {
+                #(
+                    fn #iter_methods(#level_method_inputs) -> #composite_iters<'_, NodeType>;
+                )*
+            }
+
+            impl<Nodes: NextNode + #level_trait> #iter_trait<Nodes> for Composite<Nodes> {
+                #(
+                    fn #iter_methods(#level_method_inputs) -> #composite_iters<'_, Nodes> {
+                        #composite_iters::new(&self.head, #trait_method_args)
+                    }
+                )*
+            }
+
+            #(
+                struct #composite_iters<'a, Nodes: NextNode + #level_trait> {
+                    level: usize,
+                    #trait_method_inputs,
+                    parent: &'a Nodes,
+                }
+
+
+                impl<'a, Nodes: NextNode + #level_trait> #composite_iters<'a, Nodes> {
+                    fn new(parent: &'a Nodes, #trait_method_inputs) -> Self {
+                        Self {
+                            parent,
+                            #trait_method_args,
+                            level: 0,
+                        }
+                    }
+                }
+
+                impl<'a, Nodes: NextNode + #level_trait> Iterator for #composite_iters<'a, Nodes> {
+                    type Item = #trait_method_outputs;
+
+                    #[inline]
+                    fn next(&mut self) -> Option<Self::Item> {
+                        let result = self.parent.#level_methods(#trait_method_self_args, self.level);
+                        self.level += 1;
+                        result
+                    }
+                }
+            )*
+        };
+
+        TokenStream::from(tokens)
+    }
+}
+
+impl Parse for TraitTypes {
+    fn parse(_input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {})
+    }
+}

--- a/zero_v_gen/tests/int_op_test.rs
+++ b/zero_v_gen/tests/int_op_test.rs
@@ -1,0 +1,104 @@
+use zero_v::compose;
+use zero_v_gen::zero_v_gen;
+
+#[zero_v_gen]
+trait IntOp {
+    fn execute_1(&self, input: usize) -> usize;
+    fn execute_2(&self, input_1: usize, input_2: usize) -> usize;
+}
+
+struct Adder {
+    value: usize,
+}
+
+impl Adder {
+    fn new(value: usize) -> Self {
+        Self { value }
+    }
+}
+
+impl IntOp for Adder {
+    fn execute_1(&self, input: usize) -> usize {
+        input + self.value
+    }
+    fn execute_2(&self, input_1: usize, input_2: usize) -> usize {
+        input_1 + input_2 + self.value
+    }
+}
+
+struct Multiplier {
+    value: usize,
+}
+
+impl Multiplier {
+    fn new(value: usize) -> Self {
+        Self { value }
+    }
+}
+
+impl IntOp for Multiplier {
+    fn execute_1(&self, input: usize) -> usize {
+        input * self.value
+    }
+    fn execute_2(&self, input_1: usize, input_2: usize) -> usize {
+        input_1 * input_2 * self.value
+    }
+}
+
+struct RShifter {
+    value: usize,
+}
+
+impl RShifter {
+    fn new(value: usize) -> Self {
+        Self { value }
+    }
+}
+
+impl IntOp for RShifter {
+    fn execute_1(&self, input: usize) -> usize {
+        input >> self.value
+    }
+    fn execute_2(&self, input_1: usize, input_2: usize) -> usize {
+        input_1 >> input_2 >> self.value
+    }
+}
+
+struct LShifter {
+    value: usize,
+}
+
+impl LShifter {
+    fn new(value: usize) -> Self {
+        Self { value }
+    }
+}
+
+impl IntOp for LShifter {
+    fn execute_1(&self, input: usize) -> usize {
+        input << self.value
+    }
+    fn execute_2(&self, input_1: usize, input_2: usize) -> usize {
+        input_1 << input_2 << self.value
+    }
+}
+
+#[test]
+fn test_execute() {
+    let ops = compose!(
+        Adder::new(0),
+        LShifter::new(1),
+        Adder::new(2),
+        Multiplier::new(3),
+        RShifter::new(2)
+    );
+
+    let results = ops.iter_execute_1(20).collect::<Vec<_>>();
+    assert_eq!(results, vec![20, 20 << 1, 22, 20 * 3, 20 >> 2]);
+
+    let results = ops.iter_execute_2(9, 10).collect::<Vec<_>>();
+    assert_eq!(
+        results,
+        vec![19, 9 << 10 << 1, 21, 9 * 10 * 3, 9 >> 10 >> 2]
+    );
+}

--- a/zero_v_gen/tests/int_op_test.rs
+++ b/zero_v_gen/tests/int_op_test.rs
@@ -1,7 +1,7 @@
 use zero_v::compose;
-use zero_v_gen::zero_v_gen;
+use zero_v_gen::zero_v;
 
-#[zero_v_gen]
+#[zero_v(trait_types)]
 trait IntOp {
     fn execute_1(&self, input: usize) -> usize;
     fn execute_2(&self, input_1: usize, input_2: usize) -> usize;
@@ -83,6 +83,11 @@ impl IntOp for LShifter {
     }
 }
 
+#[zero_v(fn_generics, IntOp as IntOps)]
+fn execute_1(input: usize, ops: &IntOps) -> Vec<usize> {
+    ops.iter_execute_1(input).collect()
+}
+
 #[test]
 fn test_execute() {
     let ops = compose!(
@@ -101,4 +106,18 @@ fn test_execute() {
         results,
         vec![19, 9 << 10 << 1, 21, 9 * 10 * 3, 9 >> 10 >> 2]
     );
+}
+
+#[test]
+fn test_fn_generics() {
+    let ops = compose!(
+        Adder::new(0),
+        LShifter::new(1),
+        Adder::new(2),
+        Multiplier::new(3),
+        RShifter::new(2)
+    );
+
+    let results = execute_1(10, &ops);
+    assert_eq!(results, vec![10, 10 << 1, 10 + 2, 10 * 3, 10 >> 2]);
 }


### PR DESCRIPTION
heya @fergaljoconnor, I really enjoyed playing with this library, and decided to add a proc-macro that generates much of the necessary boilerplate to make it more ergonomic to implement.

The basic idea, is that a user can now tag their trait with `#[zero_v_gen]`, and then implementations of the trait can easily be used with the `compose!` macro i.e.:
```rust
#[zero_v_gen]
pub trait MyTrait {
  fn do_something(&self) -> i32;
}

pub struct MyImpl;
impl MyTrait for MyImpl {
  fn do_something(&self) -> i32 { 0 }
}

fn main() {
  let impls = compose!(MyImpl, MyImpl);
  let results: Vec<i32> = impls.iter_do_something().collect();
  println!("{:?}", results);
}
```

I also added a new `composed` proc-macro that makes writing a function that accepts a composite list much simpler, removing the need for using generated type generics. here's an example from my PR:

```rust
#[composed(IntOp as IntOps)]
fn bench_composed(input: usize, ops: &IntOps) -> usize {
    ops.iter_execute(input).sum()
}
```

I updated all the tests and example to use the new macros, and all are passing.

let me know if you like the basic idea, I don't consider this code "done" yet -- many of the conventions / API choices were mostly aesthetic on my part and I'd be happy to change things if you see them fitting in better.

anyway, I wanted to show it to you and get feedback before I put much more effort in :)